### PR TITLE
Fix while loop with deprecated each-function

### DIFF
--- a/includes/form.php
+++ b/includes/form.php
@@ -172,7 +172,7 @@ $requiredText = $form->getRequiredText();
                         'event' => $form->getTooltipEvent()
                     ));
 
-                    foreach ($elemens as $key => $element) {
+                    foreach ($elements as $key => $element) {
                         $elementClass = get_class($element);
 
                         // Label data

--- a/includes/form.php
+++ b/includes/form.php
@@ -172,7 +172,7 @@ $requiredText = $form->getRequiredText();
                         'event' => $form->getTooltipEvent()
                     ));
 
-                    while (list($key, $element) = each($elements)) {
+                    foreach ($elemens as $key => $element) {
                         $elementClass = get_class($element);
 
                         // Label data


### PR DESCRIPTION
The "each"-function is deprecated in PHP v7.0. I would really appreciate it, if you could pull my changes and update the wordpress-plugin.